### PR TITLE
Add basic GitHub Actions CI setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Build
+
+on:
+  push:
+    branches: [ final ]
+  pull_request:
+    branches: [ final ]
+  workflow_dispatch:
+
+jobs:
+  build-android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5.0.0
+
+      - name: Build Android debug APK
+        run: ./gradlew :androidApp:assembleDebug
+
+  build-ios:
+    name: Build iOS simulator app
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5.0.0
+
+      - name: Build iOS simulator app
+        run: |
+          xcodebuild build \
+          -project iosApp/iosApp.xcodeproj \
+          -configuration Debug \
+          -scheme iosApp \
+          -sdk iphonesimulator \
+          -arch arm64 \
+          -derivedDataPath ./build \
+          CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
Adds a workflow building every platform this sample supports, in debug, targeting the `final` branch:

- **Android** — `:androidApp:assembleDebug`
- **iOS** — `xcodebuild` for the simulator; the Xcode project builds the shared framework through its Gradle build phase, so this covers the Kotlin side too

Verified by running both commands locally on macOS; both pass.